### PR TITLE
Tiled makes use of the SpriteBatch API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+* Updated the Tiled class to use the SpriteBatch API for efficient drawing to canvas.
+
 ## [0.0.1]
 
 * Moving code from main repository to its own package

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,7 +15,7 @@ void main() {
 
 class TiledGame extends BaseGame {
   TiledGame() {
-    final TiledComponent tiledMap = TiledComponent('map.tmx', 16.0);
+    final TiledComponent tiledMap = TiledComponent('map.tmx', Size(16.0, 16.0));
     add(tiledMap);
     _addCoinsInMap(tiledMap);
   }

--- a/lib/tiled_component.dart
+++ b/lib/tiled_component.dart
@@ -8,7 +8,7 @@ import './tiled.dart';
 class TiledComponent extends Component {
   Tiled _tiled;
 
-  TiledComponent(String filename, double destTileSize) {
+  TiledComponent(String filename, Size destTileSize) {
     _tiled = Tiled(filename, destTileSize);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame_tiled
 description: Package to add Tiled support for the Flame game engine
-version: 0.0.1
+version: 0.1.0
 homepage: https://github.com/flame-engine/flame_tiled
 
 environment:

--- a/test/tiled_test.dart
+++ b/test/tiled_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:flame/flame.dart';
 import 'package:flutter/services.dart' show CachingAssetBundle;
@@ -10,7 +11,7 @@ import '../lib/tiled_component.dart';
 void main() {
   test('correct loads the file', () async {
     await Flame.init(bundle: TestAssetBundle());
-    final tiled = TiledComponent('x', 16);
+    final tiled = TiledComponent('x', Size(16, 16));
     await tiled.future;
     expect(1, equals(1));
   });


### PR DESCRIPTION
The current Tiled class draws each tile individually on the canvas, switching to the SpriteBatch API will give a enormous performance gain because it will only do a single call to the canvas drawing all tiles using a single atlas.

Originally from: https://github.com/flame-engine/flame/pull/412